### PR TITLE
Support iOS 14.0+ and macOS 11.0+

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,8 +5,8 @@ import PackageDescription
 let package = Package(
     name: "AsyncBluetooth",
     platforms: [
-        .macOS("12.0"),
-        .iOS("15.0")
+        .macOS("11.0"),
+        .iOS("14.0")
     ],
     products: [
         .library(

--- a/README.md
+++ b/README.md
@@ -67,9 +67,10 @@ to your Package Dependencies.
 
 ## Requirements
 
-- iOS 15.0+
-- MacOS 12.0+
+- iOS 14.0+
+- MacOS 11.0+
 - Swift 5
+- Xcoce 13.2.1+
 
 ## License
 


### PR DESCRIPTION
Now async/await APIs can be used even in iOS 13 and macOS Catalina with Xcode 13.2. AsyncBluetooth uses `Logger` and it can be used in iOS 14.0+/macOS 11.0+, so, I set these versions.