### PR TITLE
Peripheral: Fix notifications

### DIFF
--- a/Sources/Peripheral/Peripheral.swift
+++ b/Sources/Peripheral/Peripheral.swift
@@ -286,10 +286,9 @@ extension Peripheral.DelegateWrapper: CBPeripheralDelegate {
                     characteristic.uuid, result: result
                 )
             } catch {
-                guard !characteristic.isNotifying else {
-                    return
+                if !characteristic.isNotifying {
+                    Self.logger.warning("Received UpdateValue result for characteristic without a continuation")
                 }
-                Self.logger.warning("Received UpdateValue result for characteristic without a continuation")
             }
             
             guard characteristic.isNotifying else {


### PR DESCRIPTION
It seems that the following lines are not called even if you set any notify on:
https://github.com/manolofdez/AsyncBluetooth/blob/bc3e0bee46aac0fb20127872cdba9419e0402d02/Sources/Peripheral/Peripheral.swift#L298-L300

I'm not sure if my fix fits your design, but it works fine. I hope this PR is helpful.