### PR TITLE
maybe fix possible data race

### DIFF
--- a/Sources/CentralManager/CentralManager.swift
+++ b/Sources/CentralManager/CentralManager.swift
@@ -42,10 +42,9 @@ public class CentralManager {
     // MARK: Constructors
 
     public init(dispatchQueue: DispatchQueue? = nil, options: [String: Any]? = nil) {
-        self.cbCentralManager = CBCentralManager(delegate: nil, queue: dispatchQueue, options: options)
         self.context = CentralManagerContext()
         self.cbCentralManagerDelegate = DelegateWrapper(context: self.context)
-        self.cbCentralManager.delegate = self.cbCentralManagerDelegate
+        self.cbCentralManager = CBCentralManager(delegate: cbCentralManagerDelegate, queue: dispatchQueue, options: options)
     }
     
     // MARK: Public


### PR DESCRIPTION
I am not quite sure about this but I think the original code could miss a first state change the way it was. It is quite possible that staring CBCentral is slow enough for this to never happen, though. Please explain to me why my change is unnecessary, if that is the case.