### PR TITLE
make initialisers public

### DIFF
--- a/Sources/Peripheral/Characteristic.swift
+++ b/Sources/Peripheral/Characteristic.swift
@@ -6,7 +6,7 @@ import CoreBluetooth
 /// A characteristic of a remote peripheral’s service.
 /// - This class acts as a wrapper around `CBCharacteristic`.
 public struct Characteristic {
-    let cbCharacteristic: CBCharacteristic
+    public let cbCharacteristic: CBCharacteristic
     
     init(_ cbCharacteristic: CBCharacteristic) {
         self.cbCharacteristic = cbCharacteristic

--- a/Sources/Peripheral/Characteristic.swift
+++ b/Sources/Peripheral/Characteristic.swift
@@ -8,7 +8,7 @@ import CoreBluetooth
 public struct Characteristic {
     public let cbCharacteristic: CBCharacteristic
     
-    init(_ cbCharacteristic: CBCharacteristic) {
+    public init(_ cbCharacteristic: CBCharacteristic) {
         self.cbCharacteristic = cbCharacteristic
     }
     

--- a/Sources/Peripheral/Peripheral.swift
+++ b/Sources/Peripheral/Peripheral.swift
@@ -55,14 +55,14 @@ public class Peripheral {
         #endif
     }
     
-    let cbPeripheral: CBPeripheral
+    public let cbPeripheral: CBPeripheral
     
     private let context: PeripheralContext
     /// The delegate object that will receive `cbPeripheral`.
     /// - Note: We need to hold on to it because `cbPeripheral` has a weak reference to it.
     private let cbPeripheralDelegate: DelegateWrapper
     
-    init(_ cbPeripheral: CBPeripheral) {
+    public init(_ cbPeripheral: CBPeripheral) {
         self.cbPeripheral = cbPeripheral
         
         // By reusing the cbPeripheralDelegate and context, we guarantee that we will enqueue calls to the peripheral

--- a/Sources/Peripheral/Service.swift
+++ b/Sources/Peripheral/Service.swift
@@ -30,7 +30,7 @@ public struct Service {
         self.cbService.characteristics?.map { Characteristic($0) }
     }
     
-    init(_ cbService: CBService) {
+    public init(_ cbService: CBService) {
         self.cbService = cbService
     }
 }


### PR DESCRIPTION
this allows users (me!) to integrate your excellent project without going 'all in'

in my case, I don't want to refactor my work around scanning yet - but once I have my cbperipherals, it's fantastically useful to be able to do async service/characteristic discovery.

as it stands, I can't create a Peripheral from a CBPeripheral.

thanks