### PR TITLE
[Maintenance] Simplify Peripheral

### DIFF
--- a/Sources/Peripheral/Extensions/Peripheral+ReadWrite.swift
+++ b/Sources/Peripheral/Extensions/Peripheral+ReadWrite.swift
@@ -18,7 +18,7 @@ extension Peripheral {
             throw BluetoothError.characteristicNotFound
         }
         
-        try await self.readValue(for: Characteristic(characteristic))
+        try await self.readValue(for: characteristic)
         
         guard let data = characteristic.value else {
             return nil
@@ -51,7 +51,7 @@ extension Peripheral {
             throw BluetoothError.unableToConvertValueToData
         }
         
-        try await self.writeValue(data, for: Characteristic(characteristic), type: type)
+        try await self.writeValue(data, for: characteristic, type: type)
     }
     
     /// Sets notifications or indications for the value of a characteristic with a given identifier of a service
@@ -69,43 +69,51 @@ extension Peripheral {
             throw BluetoothError.characteristicNotFound
         }
         
-        try await self.setNotifyValue(enabled, for: Characteristic(characteristic))
+        try await self.setNotifyValue(enabled, for: characteristic)
     }
     
     private func findCharacteristic(
         uuid characteristicUUID: UUID,
         ofServiceWithUUID serviceUUID: UUID
-    ) async throws -> CBCharacteristic? {
+    ) async throws -> Characteristic? {
         guard let service = try await self.findService(uuid: serviceUUID) else {
             return nil
         }
         
         let characteristicCBUUID = CBUUID(nsuuid: characteristicUUID)
         let discoveredCharacteristic: () -> CBCharacteristic? = {
-            service.characteristics?.first(where: { $0.uuid == characteristicCBUUID })
+            service.cbService.characteristics?.first(where: { $0.uuid == characteristicCBUUID })
         }
         
-        if let characteristic = discoveredCharacteristic() {
-            return characteristic
+        if let cbCharacteristic = discoveredCharacteristic() {
+            return Characteristic(cbCharacteristic)
         }
         
-        try await self.discoverCharacteristics([characteristicCBUUID], for: Service(service))
+        try await self.discoverCharacteristics([characteristicCBUUID], for: service)
         
-        return discoveredCharacteristic()
+        guard let cbCharacteristic = discoveredCharacteristic() else {
+            return nil
+        }
+        
+        return Characteristic(cbCharacteristic)
     }
     
-    private func findService(uuid: UUID) async throws -> CBService? {
+    private func findService(uuid: UUID) async throws -> Service? {
         let cbUUID = CBUUID(nsuuid: uuid)
         let discoveredService: () -> CBService? = {
             self.cbPeripheral.services?.first(where: { $0.uuid == cbUUID })
         }
         
-        if let service = discoveredService() {
-            return service
+        if let cbService = discoveredService() {
+            return Service(cbService)
         }
         
         try await self.discoverServices([cbUUID])
         
-        return discoveredService()
+        guard let cbService = discoveredService() else {
+            return nil
+        }
+        
+        return Service(cbService)
     }
 }

--- a/Sources/Peripheral/Extensions/Peripheral+ReadWrite.swift
+++ b/Sources/Peripheral/Extensions/Peripheral+ReadWrite.swift
@@ -18,7 +18,7 @@ extension Peripheral {
             throw BluetoothError.characteristicNotFound
         }
         
-        try await self.readValue(for: characteristic)
+        try await self.readValue(for: Characteristic(characteristic))
         
         guard let data = characteristic.value else {
             return nil
@@ -51,7 +51,7 @@ extension Peripheral {
             throw BluetoothError.unableToConvertValueToData
         }
         
-        try await self.writeValue(data, for: characteristic, type: type)
+        try await self.writeValue(data, for: Characteristic(characteristic), type: type)
     }
     
     /// Sets notifications or indications for the value of a characteristic with a given identifier of a service
@@ -69,7 +69,7 @@ extension Peripheral {
             throw BluetoothError.characteristicNotFound
         }
         
-        try await self.setNotifyValue(enabled, for: characteristic)
+        try await self.setNotifyValue(enabled, for: Characteristic(characteristic))
     }
     
     private func findCharacteristic(
@@ -89,7 +89,7 @@ extension Peripheral {
             return characteristic
         }
         
-        try await self.discoverCharacteristics([characteristicCBUUID], for: service)
+        try await self.discoverCharacteristics([characteristicCBUUID], for: Service(service))
         
         return discoveredCharacteristic()
     }

--- a/Sources/Peripheral/Peripheral.swift
+++ b/Sources/Peripheral/Peripheral.swift
@@ -49,8 +49,11 @@ public class Peripheral {
     
     public let cbPeripheral: CBPeripheral
     
-    private let context: PeripheralContext
-    /// The delegate object that will receive `cbPeripheral`.
+    private var context: PeripheralContext {
+        cbPeripheralDelegate.context
+    }
+    
+    /// The delegate object that will receive `cbPeripheral` callbacks.
     /// - Note: We need to hold on to it because `cbPeripheral` has a weak reference to it.
     private let cbPeripheralDelegate: PeripheralDelegate
     
@@ -61,7 +64,6 @@ public class Peripheral {
         // using the same context, and that won't lose any callbacks from the CBPeripheralDelegate.
         // This is important because we can create multiple Peripherals for a single cbPeripheral.
         if let cbPeripheralDelegate = cbPeripheral.delegate as? PeripheralDelegate {
-            self.context = cbPeripheralDelegate.context
             self.cbPeripheralDelegate = cbPeripheralDelegate
             return
         }
@@ -70,8 +72,7 @@ public class Peripheral {
             Self.logger.warning("Replacing delegate for peripheral \(cbPeripheral.identifier) can cause problems.")
         }
         
-        self.context = PeripheralContext()
-        self.cbPeripheralDelegate = PeripheralDelegate(context: self.context)
+        self.cbPeripheralDelegate = PeripheralDelegate()
         self.cbPeripheral.delegate = self.cbPeripheralDelegate
     }
     

--- a/Sources/Peripheral/PeripheralDelegate.swift
+++ b/Sources/Peripheral/PeripheralDelegate.swift
@@ -1,0 +1,176 @@
+//  Copyright (c) 2023 Manuel Fernandez-Peix Perez. All rights reserved.
+
+import Foundation
+import CoreBluetooth
+import os.log
+
+class PeripheralDelegate: NSObject {
+    private static let logger = Logger(
+        subsystem: Bundle(for: PeripheralDelegate.self).bundleIdentifier ?? "",
+        category: "peripheralDelegate"
+    )
+
+    let context: PeripheralContext
+    
+    init(context: PeripheralContext) {
+        self.context = context
+    }
+}
+
+// MARK: CBPeripheralDelegate
+
+extension PeripheralDelegate: CBPeripheralDelegate {
+    func peripheral(_ cbPeripheral: CBPeripheral, didReadRSSI RSSI: NSNumber, error: Error?) {
+        Task {
+            do {
+                let result = CallbackUtils.result(for: RSSI, error: error)
+                try await self.context.readRSSIExecutor.setWorkCompletedWithResult(result)
+            } catch {
+                Self.logger.error("Received ReadRSSI response without a continuation")
+            }
+        }
+    }
+    
+    func peripheral(_ cbPeripheral: CBPeripheral, didDiscoverServices error: Error?) {
+        Task {
+            do {
+                let result = CallbackUtils.result(for: (), error: error)
+                try await self.context.discoverServiceExecutor.setWorkCompletedWithResult(result)
+            } catch {
+                Self.logger.warning("Received DiscoverServices response without a continuation")
+            }
+        }
+    }
+    
+    func peripheral(_ cbPeripheral: CBPeripheral, didDiscoverIncludedServicesFor service: CBService, error: Error?) {
+        Task {
+            do {
+                let result = CallbackUtils.result(for: (), error: error)
+                try await self.context.discoverIncludedServicesExecutor.setWorkCompletedForKey(
+                    service.uuid, result: result
+                )
+            } catch {
+                Self.logger.warning("Received DiscoverIncludedServices response without a continuation")
+            }
+        }
+    }
+    
+    func peripheral(_ cbPeripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
+        Task {
+            do {
+                let result = CallbackUtils.result(for: (), error: error)
+                try await self.context.discoverCharacteristicsExecutor.setWorkCompletedForKey(
+                    service.uuid, result: result
+                )
+            } catch {
+                Self.logger.warning("Received DiscoverCharacteristics result without a continuation")
+            }
+        }
+    }
+    
+    func peripheral(_ cbPeripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
+        
+        if characteristic.isNotifying {
+           
+           // characteristic.value is Data() and it will get trampled if allowed to run async.
+           self.context.characteristicValueUpdatedSubject.send( Characteristic(characteristic) )
+
+        }
+           
+        Task {
+            do {
+                let result = CallbackUtils.result(for: (), error: error)
+                try await self.context.readCharacteristicValueExecutor.setWorkCompletedForKey(
+                    characteristic.uuid, result: result
+                )
+            } catch {
+                guard !characteristic.isNotifying else { return }
+                Self.logger.warning("Received UpdateValue result for characteristic without a continuation")
+            }
+        }
+    }
+    
+    func peripheral(_ cbPeripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?) {
+        Task {
+            do {
+                let result = CallbackUtils.result(for: (), error: error)
+                try await self.context.writeCharacteristicValueExecutor.setWorkCompletedForKey(
+                    characteristic.uuid, result: result
+                )
+            } catch {
+                Self.logger.warning("Received WriteValue result for characteristic without a continuation")
+            }
+        }
+    }
+    
+    func peripheral(
+        _ cbPeripheral: CBPeripheral,
+        didUpdateNotificationStateFor characteristic: CBCharacteristic,
+        error: Error?
+    ) {
+        Task {
+            do {
+                let result = CallbackUtils.result(for: (), error: error)
+                try await self.context.setNotifyValueExecutor.setWorkCompletedForKey(
+                    characteristic.uuid, result: result
+                )
+            } catch {
+                Self.logger.warning("Received UpdateNotificationState result without a continuation")
+            }
+        }
+    }
+    
+    func peripheral(
+        _ cbPeripheral: CBPeripheral,
+        didDiscoverDescriptorsFor characteristic: CBCharacteristic,
+        error: Error?
+    ) {
+        Task {
+            do {
+                let result = CallbackUtils.result(for: (), error: error)
+                try await self.context.discoverDescriptorsExecutor.setWorkCompletedForKey(
+                    characteristic.uuid, result: result
+                )
+            } catch {
+                Self.logger.warning("Received DiscoverDescriptors result without a continuation")
+            }
+        }
+    }
+    
+    func peripheral(_ cbPeripheral: CBPeripheral, didUpdateValueFor descriptor: CBDescriptor, error: Error?) {
+        Task {
+            do {
+                let result = CallbackUtils.result(for: (), error: error)
+                try await self.context.readDescriptorValueExecutor.setWorkCompletedForKey(
+                    descriptor.uuid, result: result
+                )
+            } catch {
+                Self.logger.warning("Received UpdateValue result for descriptor without a continuation")
+            }
+        }
+    }
+    
+    func peripheral(_ cbPeripheral: CBPeripheral, didWriteValueFor descriptor: CBDescriptor, error: Error?) {
+        Task {
+            do {
+                let result = CallbackUtils.result(for: (), error: error)
+                try await self.context.writeDescriptorValueExecutor.setWorkCompletedForKey(
+                    descriptor.uuid, result: result
+                )
+            } catch {
+                Self.logger.warning("Received WriteValue result for descriptor without a continuation")
+            }
+        }
+    }
+    
+    func peripheral(_ cbPeripheral: CBPeripheral, didOpen channel: CBL2CAPChannel?, error: Error?) {
+        Task {
+            do {
+                let result = CallbackUtils.result(for: channel, error: error)
+                try await self.context.openL2CAPChannelExecutor.setWorkCompletedWithResult(result)
+            } catch {
+                Self.logger.warning("Received OpenChannel result without a continuation")
+            }
+        }
+    }
+}

--- a/Sources/Peripheral/PeripheralDelegate.swift
+++ b/Sources/Peripheral/PeripheralDelegate.swift
@@ -10,11 +10,7 @@ class PeripheralDelegate: NSObject {
         category: "peripheralDelegate"
     )
 
-    let context: PeripheralContext
-    
-    init(context: PeripheralContext) {
-        self.context = context
-    }
+    let context = PeripheralContext()
 }
 
 // MARK: CBPeripheralDelegate


### PR DESCRIPTION
## Summary

The Peripheral was a little too complex, making it harder to follow and easier to make otherwise easily avoidable mistakes.

## Changes
- Peripheral and delegate are in separate files
- Removed the internal CoreBluetooth overloads 