### PR TITLE
[Bugfix] Avoid crash when cancelling operations while scanning

### DIFF
--- a/Sources/CentralManager/CentralManager.swift
+++ b/Sources/CentralManager/CentralManager.swift
@@ -84,13 +84,15 @@ public class CentralManager {
     ) async throws -> AsyncStream<ScanData> {
         try await withCheckedThrowingContinuation { continuation in
             Task {
+                // Note that the enqueue call will remain awaiting until the stream is terminated. This
+                // means that we can end up in a state were the continuation is used to send the stream,
+                // and yet we want to throw an error (e.g. calling `cancellAllOperations` while scanning).
+                // To avoid crashing, we check whether the continuation has been used before.
                 var isContinuationUsed = false
+                
                 do {
                     try await self.context.scanForPeripheralsExecutor.enqueue {
-                        guard !isContinuationUsed else {
-                            return
-                        }
-                        
+                        guard !isContinuationUsed else { return }
                         isContinuationUsed = true
                         
                         let scanDataStream = self.createScanDataStream(
@@ -100,10 +102,7 @@ public class CentralManager {
                         continuation.resume(returning: scanDataStream)
                     }
                 } catch {
-                    guard !isContinuationUsed else {
-                        return
-                    }
-                    
+                    guard !isContinuationUsed else { return }
                     isContinuationUsed = true
                     
                     continuation.resume(throwing: error)


### PR DESCRIPTION
`scanForPeripherals` will resume with an async stream, but the enqueue call stays awaiting until the stream terminates. Which opens it up for reuse, causing a crash. We need to revisit this strategy. For now, this workaround will avoid the crash.