### PR TITLE
Provide better support on characterstics notify subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ peripheral.characteristicValueUpdatedPublisher
     .store(in: &cancellables)
 ```
 
+Remember that you should enable notifications on that characteristc to receive updated values.
+
+```swift
+try await peripheral.setNotifyValue(true, characteristicUUID, serviceUUID)
+```
+
 ### Canceling operations
 
 To cancel a specific operation, you can wrap your call in a `Task`:


### PR DESCRIPTION
Update README to provide better support on characterstics notify subscription.
From current README is not clear that you are still required to call `setNotifyValue` on peripheral.