### PR TITLE
Adding support for `registerForConnectionEvents`

### DIFF
--- a/Sources/CentralManager/CentralManagerEvent.swift
+++ b/Sources/CentralManager/CentralManagerEvent.swift
@@ -8,4 +8,7 @@ public enum CentralManagerEvent {
     case willRestoreState(state: [String: Any])
     case didConnectPeripheral(peripheral: Peripheral)
     case didDisconnectPeripheral(peripheral: Peripheral, isReconnecting: Bool = false, error: Error?)
+
+    @available(macOS, unavailable)
+    case connectionEventDidOccur(connectionEvent: CBConnectionEvent, peripheral: Peripheral)
 }


### PR DESCRIPTION
This adds support for `registerForConnectionEvents` in `CentralManager` which was missing in the original implementation.

Not sure if the way I did is a good idea (I went for the simplest route), might be the case it makes more sense to use together with `connect` or `disconnect`.

My use case is that we passively wait for reconnection using the library in our project when we restore the state or lose connection.