### PR TITLE
[Feature] Partial strict concurrency support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ try await centralManager.connect(peripheral, options: nil)
 The central manager publishes several events. You can subscribe to them by using the `eventPublisher`.
 
 ```swift
-centralManager.eventPublisher
+await centralManager.eventPublisher
     .sink {
         switch $0 {
         case .didConnectPeripheral(let peripheral):
@@ -92,7 +92,7 @@ To get notified when a characteristic's value is updated, we provide a publisher
 
 ```swift
 let characteristicUUID = CBUUID()
-peripheral.characteristicValueUpdatedPublisher
+await peripheral.characteristicValueUpdatedPublisher
     .filter { $0.uuid == characteristicUUID }
     .map { try? $0.parsedValue() as String? } // replace `String?` with your type
     .sink { value in
@@ -129,7 +129,7 @@ fetchTask.cancel()
 There might also be cases were you want to stop awaiting for all responses. For example, when bluetooth has been powered off. This can be done like so:
 
 ```swift
-centralManager.eventPublisher
+await centralManager.eventPublisher
     .sink {
         switch $0 {
         case .didUpdateState(let state):

--- a/Sources/CentralManager/CentralManager.swift
+++ b/Sources/CentralManager/CentralManager.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 @preconcurrency import CoreBluetooth
-@preconcurrency import Combine
+import Combine
 import os.log
 
 /// An object that scans for, discovers, connects to, and manages peripherals using concurrency.

--- a/Sources/CentralManager/CentralManager.swift
+++ b/Sources/CentralManager/CentralManager.swift
@@ -1,12 +1,12 @@
 //  Copyright (c) 2021 Manuel Fernandez-Peix Perez. All rights reserved.
 
 import Foundation
-import CoreBluetooth
-import Combine
+@preconcurrency import CoreBluetooth
+@preconcurrency import Combine
 import os.log
 
 /// An object that scans for, discovers, connects to, and manages peripherals using concurrency.
-public class CentralManager: @unchecked Sendable {
+public final class CentralManager: Sendable {
     
     private typealias Utils = CentralManagerUtils
     

--- a/Sources/CentralManager/CentralManagerContext.swift
+++ b/Sources/CentralManager/CentralManagerContext.swift
@@ -5,7 +5,7 @@ import CoreBluetooth
 import Combine
 
 /// Contains the objects necessary to track a Central Manager's commands.
-class CentralManagerContext {
+actor CentralManagerContext {
     actor ScanForPeripheralsContext {
         let onContinuationChanged: (_ isScanning: Bool) -> Void
         
@@ -25,7 +25,9 @@ class CentralManagerContext {
     private(set) var isScanning = false
     
     private(set) lazy var scanForPeripheralsContext = ScanForPeripheralsContext { [weak self] isScanning in
-        self?.isScanning = isScanning
+        Task { [weak self] in
+            await self?.updateIsScanning(isScanning)
+        }
     }
     
     private(set) lazy var eventSubject = PassthroughSubject<CentralManagerEvent, Never>()
@@ -60,5 +62,9 @@ class CentralManagerContext {
         for try await flushableExecutor in flushableExecutors {
             try await flushableExecutor.flush(error: error)
         }
+    }
+    
+    private func updateIsScanning(_ isScanning: Bool) {
+        self.isScanning = isScanning
     }
 }

--- a/Sources/CentralManager/ScanData.swift
+++ b/Sources/CentralManager/ScanData.swift
@@ -4,10 +4,10 @@ import Foundation
 import CoreBluetooth
 
 /// Represents a single value gathered when scanning for peripheral.
-public struct ScanData: @unchecked Sendable {
+public struct ScanData: Sendable {
     public let peripheral: Peripheral
     /// A dictionary containing any advertisement and scan response data.
-    public let advertisementData: [String : Any]
+    public let advertisementData: [String : any Sendable]
     /// The current RSSI of the peripheral, in dBm. A value of 127 is reserved and indicates the RSSI
     /// was not available.
     public let rssi: NSNumber

--- a/Sources/CentralManager/ScanData.swift
+++ b/Sources/CentralManager/ScanData.swift
@@ -4,7 +4,7 @@ import Foundation
 import CoreBluetooth
 
 /// Represents a single value gathered when scanning for peripheral.
-public struct ScanData {
+public struct ScanData: @unchecked Sendable {
     public let peripheral: Peripheral
     /// A dictionary containing any advertisement and scan response data.
     public let advertisementData: [String : Any]

--- a/Sources/Peripheral/Characteristic.swift
+++ b/Sources/Peripheral/Characteristic.swift
@@ -1,11 +1,11 @@
 //  Copyright (c) 2021 Manuel Fernandez-Peix Perez. All rights reserved.
 
 import Foundation
-import CoreBluetooth
+@preconcurrency import CoreBluetooth
 
 /// A characteristic of a remote peripheral’s service.
 /// - This class acts as a wrapper around `CBCharacteristic`.
-public struct Characteristic {
+public struct Characteristic: Sendable {
     public let cbCharacteristic: CBCharacteristic
     
     public init(_ cbCharacteristic: CBCharacteristic) {

--- a/Sources/Peripheral/Peripheral.swift
+++ b/Sources/Peripheral/Peripheral.swift
@@ -14,7 +14,11 @@ public final class Peripheral: Sendable {
     }
     
     /// Publishes characteristics that are notifying of value changes.
-    public let characteristicValueUpdatedPublisher: AnyPublisher<Characteristic, Never>
+    public var characteristicValueUpdatedPublisher: AnyPublisher<Characteristic, Never> {
+        get async {
+            await self.context.characteristicValueUpdatedSubject.eraseToAnyPublisher()
+        }
+    }
     
     /// The UUID associated with the peripheral.
     public var identifier: UUID {
@@ -62,7 +66,6 @@ public final class Peripheral: Sendable {
         // This is important because we can create multiple Peripherals for a single cbPeripheral.
         if let cbPeripheralDelegate = cbPeripheral.delegate as? PeripheralDelegate {
             self.cbPeripheralDelegate = cbPeripheralDelegate
-            self.characteristicValueUpdatedPublisher = self.cbPeripheralDelegate.context.characteristicValueUpdatedSubject.eraseToAnyPublisher()
             return
         }
         
@@ -72,7 +75,6 @@ public final class Peripheral: Sendable {
         
         self.cbPeripheralDelegate = PeripheralDelegate()
         self.cbPeripheral.delegate = self.cbPeripheralDelegate
-        self.characteristicValueUpdatedPublisher = self.cbPeripheralDelegate.context.characteristicValueUpdatedSubject.eraseToAnyPublisher()
     }
     
     /// Retrieves the current RSSI value for the peripheral while connected to the central manager.

--- a/Sources/Peripheral/Peripheral.swift
+++ b/Sources/Peripheral/Peripheral.swift
@@ -7,7 +7,7 @@ import os.log
 
 /// A remote peripheral device.
 /// - This class acts as a wrapper around `CBPeripheral`.
-public class Peripheral {
+public class Peripheral: @unchecked Sendable {
         
     private static var logger: Logger {
         Logging.logger(for: "peripheral")

--- a/Sources/Peripheral/Peripheral.swift
+++ b/Sources/Peripheral/Peripheral.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 @preconcurrency import CoreBluetooth
-@preconcurrency import Combine
+import Combine
 import os.log
 
 /// A remote peripheral device.

--- a/Sources/Peripheral/PeripheralContext.swift
+++ b/Sources/Peripheral/PeripheralContext.swift
@@ -5,7 +5,7 @@ import CoreBluetooth
 import Combine
 
 /// Contains the objects necessary to track a Peripheral's commands.
-class PeripheralContext {
+actor PeripheralContext {
     private(set) lazy var characteristicValueUpdatedSubject = PassthroughSubject<Characteristic, Never>()
     private(set) lazy var invalidatedServicesSubject = PassthroughSubject<[Service], Never>()
     

--- a/Sources/Peripheral/PeripheralDelegate.swift
+++ b/Sources/Peripheral/PeripheralDelegate.swift
@@ -67,8 +67,7 @@ extension PeripheralDelegate: CBPeripheralDelegate {
     func peripheral(_ cbPeripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
         Task {
             if characteristic.isNotifying {
-               // characteristic.value is Data() and it will get trampled if allowed to run async.
-               await self.context.characteristicValueUpdatedSubject.send( Characteristic(characteristic) )
+               await self.context.characteristicValueUpdatedSubject.send(Characteristic(characteristic))
             }
 
             do {

--- a/Sources/Peripheral/PeripheralDelegate.swift
+++ b/Sources/Peripheral/PeripheralDelegate.swift
@@ -4,7 +4,7 @@ import Foundation
 import CoreBluetooth
 import os.log
 
-class PeripheralDelegate: NSObject {
+final class PeripheralDelegate: NSObject, Sendable {
     
     private static var logger: Logger {
         Logging.logger(for: "peripheralDelegate")
@@ -65,13 +65,12 @@ extension PeripheralDelegate: CBPeripheralDelegate {
     }
     
     func peripheral(_ cbPeripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
-        
-        if characteristic.isNotifying {
-           // characteristic.value is Data() and it will get trampled if allowed to run async.
-           self.context.characteristicValueUpdatedSubject.send( Characteristic(characteristic) )
-        }
-           
         Task {
+            if characteristic.isNotifying {
+               // characteristic.value is Data() and it will get trampled if allowed to run async.
+               await self.context.characteristicValueUpdatedSubject.send( Characteristic(characteristic) )
+            }
+
             do {
                 let result = CallbackUtils.result(for: (), error: error)
                 try await self.context.readCharacteristicValueExecutor.setWorkCompletedForKey(
@@ -169,6 +168,8 @@ extension PeripheralDelegate: CBPeripheralDelegate {
     }
     
     func peripheral(_ peripheral: CBPeripheral, didModifyServices invalidatedServices: [CBService]) {
-        self.context.invalidatedServicesSubject.send(invalidatedServices.map { Service($0) })
+        Task {
+            await self.context.invalidatedServicesSubject.send(invalidatedServices.map { Service($0) })
+        }
     }
 }

--- a/Sources/Peripheral/Service.swift
+++ b/Sources/Peripheral/Service.swift
@@ -1,11 +1,11 @@
 //  Copyright (c) 2021 Manuel Fernandez-Peix Perez. All rights reserved.
 
 import Foundation
-import CoreBluetooth
+@preconcurrency import CoreBluetooth
 
 /// A collection of data and associated behaviors that accomplish a function or feature of a device.
 /// - This class acts as a wrapper around `CBService`.
-public struct Service: @unchecked Sendable {
+public struct Service: Sendable {
     let cbService: CBService
     
     /// The Bluetooth-specific UUID of the service.

--- a/Sources/Peripheral/Service.swift
+++ b/Sources/Peripheral/Service.swift
@@ -5,7 +5,7 @@ import CoreBluetooth
 
 /// A collection of data and associated behaviors that accomplish a function or feature of a device.
 /// - This class acts as a wrapper around `CBService`.
-public struct Service {
+public struct Service: @unchecked Sendable {
     let cbService: CBService
     
     /// The Bluetooth-specific UUID of the service.

--- a/Sources/Utils/Extensions/CBUUID+Sendable.swift
+++ b/Sources/Utils/Extensions/CBUUID+Sendable.swift
@@ -1,0 +1,6 @@
+// Copyright (c) 2024 Manuel Fernandez. All rights reserved.
+
+import Foundation
+import CoreBluetooth
+
+extension CBUUID: @unchecked Sendable {}


### PR DESCRIPTION
Address the warnings resulting from toggling Strict concurrency checking to `Complete`. Unfortunately we rely on some CoreBluetooth data types which don't support strict concurrency. In order to avoid significant rewrites, we opted for hiding the Sendable warnings from CoreBluetooth behind the `@preconcurrency` attribute (for now).

Note this PR contains breaking changes around accessing the event publishers.