### PR TITLE
Bugfix: Make Characteristic immutable wrapper of CBCharacteristic

### DIFF
--- a/Sources/Peripheral/Characteristic.swift
+++ b/Sources/Peripheral/Characteristic.swift
@@ -7,33 +7,18 @@ import Foundation
 /// - This class acts as a wrapper around `CBCharacteristic`.
 public struct Characteristic: Sendable {
     public let cbCharacteristic: CBCharacteristic
-    
+    public let uuid: CBUUID
+    public let properties: CBCharacteristicProperties
+    public let value: Data?
+    public let descriptors: [Descriptor]?
+    public let isNotifying: Bool
+
     public init(_ cbCharacteristic: CBCharacteristic) {
         self.cbCharacteristic = cbCharacteristic
-    }
-    
-    /// The Bluetooth-specific UUID of the characteristic.
-    public var uuid: CBUUID {
-        self.cbCharacteristic.uuid
-    }
-    
-    public var properties: CBCharacteristicProperties {
-        self.cbCharacteristic.properties
-    }
-    
-    /// The latest value read for this characteristic.
-    public var value: Data? {
-        self.cbCharacteristic.value
-    }
-
-    /// A list of the descriptors discovered in this characteristic.
-    public var descriptors: [Descriptor]? {
-        self.cbCharacteristic.descriptors?.map { Descriptor($0) }
-    }
-
-    /// A Boolean value that indicates whether the characteristic is currently notifying a subscribed central
-    /// of its value.
-    public var isNotifying: Bool {
-        self.cbCharacteristic.isNotifying
+        self.uuid = cbCharacteristic.uuid
+        self.properties = cbCharacteristic.properties
+        self.value = cbCharacteristic.value
+        self.descriptors = cbCharacteristic.descriptors?.map { Descriptor($0) }
+        self.isNotifying = cbCharacteristic.isNotifying
     }
 }

--- a/Sources/Peripheral/Descriptor.swift
+++ b/Sources/Peripheral/Descriptor.swift
@@ -1,11 +1,11 @@
 //  Copyright (c) 2021 Manuel Fernandez-Peix Perez. All rights reserved.
 
 import Foundation
-import CoreBluetooth
+@preconcurrency import CoreBluetooth
 
 /// An object that provides further information about a remote peripheral’s characteristic.
 /// - This class acts as a wrapper for `CBDescriptor`.
-public struct Descriptor {
+public struct Descriptor: Sendable {
     let cbDescriptor: CBDescriptor
     
     init(_ cbDescriptor: CBDescriptor) {


### PR DESCRIPTION
Wrapper of CBCharacteristic shouldn't be mutable, because its value can change while eventData is forwarded to the observers (bluetoothDevice.peripheral.characteristicValueUpdatedPublisher.sink). 

In our case, sending multiple different values through Nordic BLE resulted in receiveing same event multiple times while some events were lost. Making Characteristic immutable solved the issue in our case. 

I hope this helps. Cheers.  
