### PR TITLE
[Bugfix] Fix Swift 6 crash when sending to a subscription from a MainActor

### DIFF
--- a/Sources/CentralManager/CentralManager.swift
+++ b/Sources/CentralManager/CentralManager.swift
@@ -240,9 +240,9 @@ extension CentralManager.DelegateWrapper: CBCentralManagerDelegate {
     }()
     
     func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        self.context.eventSubject.send(.didUpdateState(state: central.state))
+        
         Task {
-            self.context.eventSubject.send(.didUpdateState(state: central.state))
-            
             guard let isBluetoothReadyResult = Utils.isBluetoothReady(central.state) else { return }
 
             await self.context.waitUntilReadyExecutor.flush(isBluetoothReadyResult)
@@ -288,11 +288,11 @@ extension CentralManager.DelegateWrapper: CBCentralManagerDelegate {
             } catch {
                 Self.logger.info("Received onDidConnect without a continuation")
             }
-            
-            self.context.eventSubject.send(
-                .didConnectPeripheral(peripheral: Peripheral(peripheral))
-            )
         }
+        
+        self.context.eventSubject.send(
+            .didConnectPeripheral(peripheral: Peripheral(peripheral))
+        )
     }
 
     #if !os(macOS)
@@ -355,11 +355,11 @@ extension CentralManager.DelegateWrapper: CBCentralManagerDelegate {
             } catch {
                 Self.logger.info("Disconnected from \(peripheral.identifier) without a continuation")
             }
-            
-            self.context.eventSubject.send(
-                .didDisconnectPeripheral(peripheral: Peripheral(peripheral), isReconnecting: isReconnecting, error: error)
-            )
         }
+        
+        self.context.eventSubject.send(
+            .didDisconnectPeripheral(peripheral: Peripheral(peripheral), isReconnecting: isReconnecting, error: error)
+        )
     }
     
     func centralManager(
@@ -377,10 +377,10 @@ extension CentralManager.DelegateWrapper: CBCentralManagerDelegate {
             } catch {
                 Self.logger.info("Disconnected from \(peripheral.identifier) without a continuation")
             }
-            
-            self.context.eventSubject.send(
-                .didDisconnectPeripheral(peripheral: Peripheral(peripheral), isReconnecting: false, error: error)
-            )
         }
+        
+        self.context.eventSubject.send(
+            .didDisconnectPeripheral(peripheral: Peripheral(peripheral), isReconnecting: false, error: error)
+        )
     }
 }

--- a/Sources/Peripheral/PeripheralDelegate.swift
+++ b/Sources/Peripheral/PeripheralDelegate.swift
@@ -67,11 +67,11 @@ extension PeripheralDelegate: CBPeripheralDelegate {
     func peripheral(_ cbPeripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
         let eventData = CharacteristicValueUpdateEventData(characteristic: Characteristic(characteristic))
         
+        if characteristic.isNotifying {
+           self.context.characteristicValueUpdatedSubject.send(eventData)
+        }
+        
         Task {
-            if characteristic.isNotifying {
-               self.context.characteristicValueUpdatedSubject.send(eventData)
-            }
-
             do {
                 let result = CallbackUtils.result(for: (), error: error)
                 try await self.context.readCharacteristicValueExecutor.setWorkCompletedForKey(


### PR DESCRIPTION
Sending values through the `PassthroughSubject`s with subscriptions from a `MainActor` causes a crash in Swift 6. This doesn't seem to be reproducible in Swift 5 with complete Strict Concurrency Checking.

A very similar issue has been raised in the swift.org forum [here](https://forums.swift.org/t/crash-in-combine-related-to-swift-6-concurrency/75178).

For now, we'll just take the publishers out of the Tasks.