### PR TITLE
[Bugfix] Fix wrong condition about `writeValue(_:for:type:)`'s WriteType

### DIFF
--- a/Sources/Peripheral/Peripheral.swift
+++ b/Sources/Peripheral/Peripheral.swift
@@ -156,7 +156,7 @@ public final class Peripheral: Sendable {
             
             self.cbPeripheral.writeValue(data, for: characteristic.cbCharacteristic, type: type)
             
-            guard type == .withoutResponse else {
+            guard type == .withResponse else {
                 return
             }
             


### PR DESCRIPTION
The condition of write type checking on writeValue(_:for:type:) is wrong.

Condition on guard-statement should be `type == .withResponse` not a `type == .withoutResponse`
