### PR TITLE
[Maintenance] Make cancelAllOperations non throwing. Aligns to Peripheral

### DIFF
--- a/Sources/CentralManager/CentralManager.swift
+++ b/Sources/CentralManager/CentralManager.swift
@@ -184,11 +184,11 @@ public final class CentralManager: Sendable {
     
     /// Cancels all pending operations, stops scanning and awaiting for any responses.
     /// - Note: Operation for Peripherals will not be cancelled. To do that, call `cancelAllOperations()` on the `Peripheral`.
-    public func cancelAllOperations() async throws {
+    public func cancelAllOperations() async {
         if await isScanning {
             await self.stopScan()
         }
-        try await self.context.flush(error: BluetoothError.operationCancelled)
+        await self.context.flush(error: BluetoothError.operationCancelled)
     }
 
     /// Returns a Boolean that indicates whether the device supports a specific set of features.

--- a/Sources/CentralManager/CentralManagerContext.swift
+++ b/Sources/CentralManager/CentralManagerContext.swift
@@ -58,7 +58,7 @@ actor CentralManagerContext {
     
     private var flushableExecutors: ThreadSafeArray<FlushableExecutor> = []
     
-    func flush(error: Error) async throws {
+    func flush(error: Error) async {
         for await flushableExecutor in flushableExecutors {
             await flushableExecutor.flush(error: error)
         }


### PR DESCRIPTION
- updates `flush` on `CentralManagerContext` to be non throwing
- updates `cancelAllOperations` on `CentralManager` to be non throwing

This aligns the `Peripheral` and `CentralManager` equivalent `cancelAllOperations` functions