### PR TITLE
Swift 6 Fixes & Characteristic Access Error

### DIFF
--- a/Sources/CentralManager/CentralManagerContext.swift
+++ b/Sources/CentralManager/CentralManagerContext.swift
@@ -30,7 +30,7 @@ actor CentralManagerContext {
         }
     }
     
-    nonisolated private(set) lazy var eventSubject = PassthroughSubject<CentralManagerEvent, Never>()
+    nonisolated let eventSubject = PassthroughSubject<CentralManagerEvent, Never>()
     
     private(set) lazy var waitUntilReadyExecutor = {
         let executor = AsyncSerialExecutor<Void>()

--- a/Sources/Peripheral/CharacteristicValueUpdateEventData.swift
+++ b/Sources/Peripheral/CharacteristicValueUpdateEventData.swift
@@ -8,10 +8,24 @@ public struct CharacteristicValueUpdateEventData {
     /// The value the characteristic changed to. We store it separately from the characteristic
     /// to avoid data races, given that the underlying CBCharacteristic's value might change
     /// before clients receive the publisher's value.
-    public let value: Data?
-    
-    init(characteristic: Characteristic) {
+    public var value: Data? {
+        try? valueResult.get()
+    }
+
+    /**
+     A `Result` representing the outcome of reading the characteristic's value at the time of the update.
+     If the update was successful, contains the value as `Data?`.
+     If an error occurred during the update (such as in `peripheral(_:didUpdateValueFor:error:)`), contains the error.
+     This is stored separately from the characteristic to avoid data races, ensuring clients access the correct value or error as it existed at the update event.
+     */
+    public let valueResult: Result<Data?, Error>
+
+    init(characteristic: Characteristic, error: Error?) {
         self.characteristic = characteristic
-        self.value = characteristic.value
+        if let error {
+            self.valueResult = .failure(error)
+        } else {
+            self.valueResult = .success(characteristic.value)
+        }
     }
 }

--- a/Sources/Peripheral/PeripheralContext.swift
+++ b/Sources/Peripheral/PeripheralContext.swift
@@ -6,8 +6,8 @@ import Combine
 
 /// Contains the objects necessary to track a Peripheral's commands.
 actor PeripheralContext {
-    nonisolated private(set) lazy var characteristicValueUpdatedSubject = PassthroughSubject<CharacteristicValueUpdateEventData, Never>()
-    nonisolated private(set) lazy var invalidatedServicesSubject = PassthroughSubject<[Service], Never>()
+    nonisolated let characteristicValueUpdatedSubject = PassthroughSubject<CharacteristicValueUpdateEventData, Never>()
+    nonisolated let invalidatedServicesSubject = PassthroughSubject<[Service], Never>()
     
     private(set) lazy var readRSSIExecutor = {
         let executor = AsyncSerialExecutor<NSNumber>()

--- a/Sources/Peripheral/PeripheralDelegate.swift
+++ b/Sources/Peripheral/PeripheralDelegate.swift
@@ -65,7 +65,7 @@ extension PeripheralDelegate: CBPeripheralDelegate {
     }
     
     func peripheral(_ cbPeripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
-        let eventData = CharacteristicValueUpdateEventData(characteristic: Characteristic(characteristic))
+        let eventData = CharacteristicValueUpdateEventData(characteristic: Characteristic(characteristic), error: error)
         
         if characteristic.isNotifying {
            self.context.characteristicValueUpdatedSubject.send(eventData)


### PR DESCRIPTION
### [Maintenance] Swift 6 compatibility
- Fixed warnings(future errors) in Swift 6 language mode.
### [Feature] Error on characteristic value access
- Added explicit error when accessing a characteristic’s value fails, improving error handling and debugging.