### PR TITLE
[Maintenance] Fix random crashes when accessing loggers when enabled

### DIFF
--- a/Sources/CentralManager/CentralManager.swift
+++ b/Sources/CentralManager/CentralManager.swift
@@ -18,9 +18,7 @@ public final class CentralManager: Sendable {
         }
     }
     
-    private static var logger: Logger {
-        Logging.logger(for: "centralManager")
-    }
+    private static let logger = AsyncBluetoothLogging.createLogger(for: "centralManager")
     
     public var bluetoothState: CBManagerState {
         self.cbCentralManager.state

--- a/Sources/Peripheral/Peripheral.swift
+++ b/Sources/Peripheral/Peripheral.swift
@@ -9,9 +9,7 @@ import os.log
 /// - This class acts as a wrapper around `CBPeripheral`.
 public final class Peripheral: Sendable {
         
-    private static var logger: Logger {
-        Logging.logger(for: "peripheral")
-    }
+    private static let logger = AsyncBluetoothLogging.createLogger(for: "peripheral")
     
     /// Publishes characteristics that are notifying of value changes.
     public var characteristicValueUpdatedPublisher: AnyPublisher<CharacteristicValueUpdateEventData, Never> {

--- a/Sources/Peripheral/PeripheralDelegate.swift
+++ b/Sources/Peripheral/PeripheralDelegate.swift
@@ -6,9 +6,7 @@ import os.log
 
 final class PeripheralDelegate: NSObject, Sendable {
     
-    private static var logger: Logger {
-        Logging.logger(for: "peripheralDelegate")
-    }
+    private static let logger = AsyncBluetoothLogging.createLogger(for: "peripheralDelegate")
 
     let context = PeripheralContext()
 }

--- a/Sources/Utils/AsyncBluetoothLogging.swift
+++ b/Sources/Utils/AsyncBluetoothLogging.swift
@@ -7,29 +7,18 @@ public final class AsyncBluetoothLogging: Sendable {
     
     private(set) static var isEnabled = true
     
-    private static var loggers: [String: Logger] = [:]
     private static let disabledLogger = Logger(OSLog.disabled)
     
     public static func setEnabled(_ isEnabled: Bool) {
         Self.isEnabled = isEnabled
     }
     
-    static func logger(for category: String) -> Logger {
+    static func createLogger(for category: String) -> Logger {
         guard Self.isEnabled else { return Self.disabledLogger }
         
-        if let logger = Self.loggers[category] {
-            return logger
-        }
-        
-        let logger = Logger(
+        return Logger(
             subsystem: Bundle(for: CentralManager.self).bundleIdentifier ?? "",
             category: category
         )
-        
-        Self.loggers[category] = logger
-        
-        return logger
     }
 }
-
-typealias Logging = AsyncBluetoothLogging

--- a/Sources/Utils/AsyncExecutorMap.swift
+++ b/Sources/Utils/AsyncExecutorMap.swift
@@ -3,14 +3,12 @@
 import Foundation
 import os.log
 
+private let asyncExecuterMapLogger = AsyncBluetoothLogging.createLogger(for: "asyncExecuterMap")
+
 /// Executes work in parallel when keys are different, and serially when there's work queued for a given key.
 /// After work for a given key has started, this class will await until the client completes it before taking
 /// on the next work for that key.
 actor AsyncExecutorMap<Key, Value> where Key: Hashable {
-    
-    private static var logger: Logger {
-        Logging.logger(for: "asyncExecuterMap")
-    }
     
     enum AsyncExecutorMapError: Error {
         case executorNotFound
@@ -72,7 +70,7 @@ extension AsyncExecutorMap: FlushableExecutor {
             do {
                 try await self.flush(key: key, result: .failure(error))
             } catch {
-                Self.logger.warning("Unable to flush executor with key: \("\(key)").")
+                asyncExecuterMapLogger.warning("Unable to flush executor with key: \("\(key)").")
             }
         }
     }


### PR DESCRIPTION
When `AsyncBluetoothLogging` is accessed from different contexts, you can run into a situation where the cached logger dictionary is accessed and mutated at the same time, causing a crash.

To prevent this, lets cache them in the places where they're used.