### PR TITLE
Remove legacy didDisconnectPeripheral:error: delegate method

### DIFF
--- a/Sources/CentralManager/CentralManager.swift
+++ b/Sources/CentralManager/CentralManager.swift
@@ -363,26 +363,4 @@ extension CentralManager.DelegateWrapper: CBCentralManagerDelegate {
             .didDisconnectPeripheral(peripheral: peripheral, isReconnecting: isReconnecting, error: error)
         )
     }
-    
-    func centralManager(
-        _ cbCentralManager: CBCentralManager,
-        didDisconnectPeripheral peripheral: CBPeripheral,
-        error: Error?
-    ) {
-        Task {
-            do {
-                let result = CallbackUtils.result(for: (), error: error)
-                try await self.context.cancelPeripheralConnectionExecutor.setWorkCompletedForKey(
-                    peripheral.identifier, result: result
-                )
-                Self.logger.info("Disconnected from \(peripheral.identifier)")
-            } catch {
-                Self.logger.info("Disconnected from \(peripheral.identifier) without a continuation")
-            }
-        }
-        
-        self.context.eventSubject.send(
-            .didDisconnectPeripheral(peripheral: Peripheral(peripheral), isReconnecting: false, error: error)
-        )
-    }
 }


### PR DESCRIPTION
When both `centralManager(_:didDisconnectPeripheral:error:)` and `centralManager(_:didDisconnectPeripheral:timestamp:isReconnecting:error:)` are implemented, CoreBluetooth always dispatches to the legacy one, preventing the newer `timestamp`/`isReconnecting` variant from being called.

This breaks auto-reconnection when connecting with [CBConnectPeripheralOptionEnableAutoReconnect](https://developer.apple.com/documentation/corebluetooth/cbconnectperipheraloptionenableautoreconnect):

```swift
centralManager.connect(
    peripheral,
    options: [CBConnectPeripheralOptionEnableAutoReconnect: true]
)
```
With both methods present, auto-reconnection never happens. Removing the legacy method allows CoreBluetooth to call the newer variant, which correctly reports isReconnecting: true and enables the system to automatically reconnect to the peripheral.